### PR TITLE
Scale loaded sprites to requested size

### DIFF
--- a/neon_dodge.py
+++ b/neon_dodge.py
@@ -102,8 +102,13 @@ random.seed()
 # sprite helper
 def load_sprite(path: str, diameter: int, color: Tuple[int, int, int]) -> Surface:
     try:
-        return pygame.image.load(path).convert_alpha()
+        # Scale any loaded image down to the requested diameter so oversized
+        # assets don't appear huge in game.  The function previously returned
+        # the raw image which ignored the desired size.
+        image = pygame.image.load(path).convert_alpha()
+        return pygame.transform.smoothscale(image, (diameter, diameter))
     except Exception:
+        # If the image can't be loaded, fall back to a simple colored circle
         surf = pygame.Surface((diameter, diameter), pygame.SRCALPHA)
         pygame.draw.circle(surf, color, (diameter // 2, diameter // 2), diameter // 2)
         return surf


### PR DESCRIPTION
## Summary
- scale loaded images to the provided diameter so sprites don't appear oversized

## Testing
- `python -m py_compile neon_dodge.py`


------
https://chatgpt.com/codex/tasks/task_e_68a23b36b5d0832aa47fc67786f5b642