### PR TITLE
Add configurable settings menu with persistent preferences

### DIFF
--- a/neon_dodge_save.json
+++ b/neon_dodge_save.json
@@ -1,1 +1,2 @@
-{"high_score": 1525}
+{"high_score": 1525, "music_volume": 1.0, "sfx_volume": 1.0, "difficulty": 1}
+


### PR DESCRIPTION
## Summary
- add SETTINGS game state and title screen shortcut
- implement settings menu for volume and difficulty with persistence
- save and reload music, sfx, and difficulty settings

## Testing
- `python -m py_compile neon_dodge.py`

------
https://chatgpt.com/codex/tasks/task_e_68a247fb7cb0832aabe909a4ad230198