### PR TITLE
Add leaderboard persistence with reset option

### DIFF
--- a/neon_dodge_save.json
+++ b/neon_dodge_save.json
@@ -1,1 +1,1 @@
-{"high_score": 1525}
+{"scores": []}


### PR DESCRIPTION
## Summary
- Track multiple top scores with kills and coins metadata
- Display leaderboard on title screen and allow clearing saved scores

## Testing
- `python -m py_compile neon_dodge.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2483938e0832a92d8b44d54433017