### PR TITLE
Fix pygame unbound error from mixer import

### DIFF
--- a/neon_dodge.py
+++ b/neon_dodge.py
@@ -377,7 +377,6 @@ class Game:
     def __init__(self):
         pygame.init()
         # Initialize mixer for sound effects and music
-        import pygame.mixer
         pygame.mixer.init()
         pygame.display.set_caption(TITLE)
         self.screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)


### PR DESCRIPTION
## Summary
- remove local `import pygame.mixer` that caused `pygame` to be treated as a local variable
- initialize the mixer directly using `pygame.mixer.init()`

## Testing
- `python -m py_compile neon_dodge.py`
- `python neon_dodge.py` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame)*

------
https://chatgpt.com/codex/tasks/task_e_68a24afe45d8832a96c65d95f9a7d3c5