### PR TITLE
Add Rogue Engine factory prototype with chunked world, belts, fixed-tick sim and instanced rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,25 @@ npm test
 ## License
 
 MIT
+
+## Rogue Engine Factory Prototype
+
+This repo includes a code-only Rogue Engine prototype for a 3D top-down factory slice.
+
+### Controls
+
+- WASD: pan camera
+- Mouse wheel: zoom
+- Middle mouse drag: pan
+- Left click: place belt
+- Right click: remove belt
+- Q/E: rotate belt direction
+- 1: inject ore into hovered belt
+- F5: save to localStorage
+- F9: load from localStorage
+
+### Running in Rogue Engine
+
+1. Open the project in Rogue Engine.
+2. Create a GameObject in the scene and add the `GameManager` component from `src/game/GameManager.ts`.
+3. Press Play to run the prototype.

--- a/src/game/GameManager.ts
+++ b/src/game/GameManager.ts
@@ -1,0 +1,51 @@
+/** Main game loop with fixed tick accumulator and chunk sync. */
+import * as RE from "rogue-engine";
+import * as THREE from "three";
+import { World } from "../world/World";
+import { Simulator } from "../sim/Simulator";
+import { InstancedBatches } from "../render/InstancedBatches";
+import { InputController } from "../input/InputController";
+
+export default class GameManager extends RE.Component {
+  private world = new World();
+  private simulator = new Simulator();
+  private renderer?: InstancedBatches;
+  private input?: InputController;
+  private accumulator = 0;
+  private readonly tickRate = 1 / 20;
+  private camera?: THREE.PerspectiveCamera;
+
+  awake(): void {
+    const scene = RE.Runtime.scene as THREE.Scene;
+    scene.background = new THREE.Color(0x111218);
+    const light = new THREE.DirectionalLight(0xffffff, 1.1);
+    light.position.set(10, 20, 10);
+    scene.add(light);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+
+    this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    scene.add(this.camera);
+
+    this.renderer = new InstancedBatches(scene);
+    this.input = new InputController(this.camera, document.body, this.world, scene);
+  }
+
+  update(): void {
+    if (!this.renderer || !this.input || !this.camera) {
+      return;
+    }
+    const delta = RE.Runtime.deltaTime ?? 0;
+    this.input.update(delta);
+    this.accumulator += delta;
+
+    const activeChunks = this.world.getActiveChunks(this.input.getCameraTarget(), 3);
+    while (this.accumulator >= this.tickRate) {
+      this.simulator.tick(this.world, activeChunks);
+      this.accumulator -= this.tickRate;
+    }
+
+    for (const chunk of activeChunks) {
+      this.renderer.syncChunk(chunk);
+    }
+  }
+}

--- a/src/input/InputController.ts
+++ b/src/input/InputController.ts
@@ -1,0 +1,197 @@
+/** Camera input, raycast placement, and hotkey handling. */
+import * as THREE from "three";
+import { World } from "../world/World";
+import { Dir, dirToYaw, rotateDir } from "../util/MathUtil";
+
+export type InputState = {
+  hoveredTile?: { tx: number; tz: number };
+  buildDir: Dir;
+};
+
+export class InputController {
+  private camera: THREE.PerspectiveCamera;
+  private domElement: HTMLElement;
+  private world: World;
+  private raycaster = new THREE.Raycaster();
+  private mouse = new THREE.Vector2();
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private intersection = new THREE.Vector3();
+
+  private target = new THREE.Vector3(0, 0, 0);
+  private zoom = 18;
+  private moveSpeed = 10;
+
+  private pressed = new Set<string>();
+  private leftClick = false;
+  private rightClick = false;
+  private middleDown = false;
+  private lastMouse = new THREE.Vector2();
+
+  private ghost: THREE.Mesh;
+  readonly state: InputState = { buildDir: Dir.East };
+
+  constructor(camera: THREE.PerspectiveCamera, domElement: HTMLElement, world: World, scene: THREE.Scene) {
+    this.camera = camera;
+    this.domElement = domElement;
+    this.world = world;
+
+    this.ghost = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 0.2, 1),
+      new THREE.MeshStandardMaterial({ color: 0x33ff99, transparent: true, opacity: 0.5 })
+    );
+    this.ghost.visible = false;
+    scene.add(this.ghost);
+
+    this.bindEvents();
+    this.updateCamera();
+  }
+
+  private bindEvents(): void {
+    window.addEventListener("keydown", (event) => {
+      this.pressed.add(event.key.toLowerCase());
+      if (event.key === "q") {
+        this.state.buildDir = rotateDir(this.state.buildDir, -1);
+      }
+      if (event.key === "e") {
+        this.state.buildDir = rotateDir(this.state.buildDir, 1);
+      }
+      if (event.key === "1") {
+        this.injectItem();
+      }
+      if (event.key === "F5") {
+        event.preventDefault();
+        this.save();
+      }
+      if (event.key === "F9") {
+        event.preventDefault();
+        this.load();
+      }
+    });
+
+    window.addEventListener("keyup", (event) => {
+      this.pressed.delete(event.key.toLowerCase());
+    });
+
+    this.domElement.addEventListener("mousedown", (event) => {
+      if (event.button === 0) {
+        this.leftClick = true;
+      }
+      if (event.button === 2) {
+        this.rightClick = true;
+      }
+      if (event.button === 1) {
+        this.middleDown = true;
+      }
+      this.lastMouse.set(event.clientX, event.clientY);
+    });
+
+    this.domElement.addEventListener("mouseup", (event) => {
+      if (event.button === 1) {
+        this.middleDown = false;
+      }
+    });
+
+    this.domElement.addEventListener("contextmenu", (event) => event.preventDefault());
+
+    this.domElement.addEventListener("mousemove", (event) => {
+      if (this.middleDown) {
+        const dx = event.clientX - this.lastMouse.x;
+        const dy = event.clientY - this.lastMouse.y;
+        this.target.x -= dx * 0.02;
+        this.target.z -= dy * 0.02;
+        this.lastMouse.set(event.clientX, event.clientY);
+        this.updateCamera();
+      }
+      const rect = this.domElement.getBoundingClientRect();
+      this.mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      this.mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    });
+
+    this.domElement.addEventListener("wheel", (event) => {
+      this.zoom += event.deltaY * 0.01;
+      this.zoom = THREE.MathUtils.clamp(this.zoom, 6, 40);
+      this.updateCamera();
+    });
+  }
+
+  update(delta: number): void {
+    const move = this.moveSpeed * delta;
+    if (this.pressed.has("w")) {
+      this.target.z -= move;
+    }
+    if (this.pressed.has("s")) {
+      this.target.z += move;
+    }
+    if (this.pressed.has("a")) {
+      this.target.x -= move;
+    }
+    if (this.pressed.has("d")) {
+      this.target.x += move;
+    }
+    this.updateCamera();
+    this.updateHover();
+    this.handleClicks();
+  }
+
+  getCameraTarget(): THREE.Vector3 {
+    return this.target;
+  }
+
+  private updateCamera(): void {
+    this.camera.position.set(this.target.x, this.zoom, this.target.z + this.zoom);
+    this.camera.lookAt(this.target.x, 0, this.target.z);
+  }
+
+  private updateHover(): void {
+    this.raycaster.setFromCamera(this.mouse, this.camera);
+    const hit = this.raycaster.ray.intersectPlane(this.plane, this.intersection);
+    if (!hit) {
+      this.ghost.visible = false;
+      this.state.hoveredTile = undefined;
+      return;
+    }
+    const { tx, tz } = this.world.worldToTile(this.intersection);
+    this.state.hoveredTile = { tx, tz };
+    const worldPos = this.world.tileToWorld(tx, tz);
+    this.ghost.position.set(worldPos.x, 0.15, worldPos.z);
+    this.ghost.rotation.set(0, dirToYaw(this.state.buildDir), 0);
+    this.ghost.visible = true;
+  }
+
+  private handleClicks(): void {
+    if (!this.state.hoveredTile) {
+      this.leftClick = false;
+      this.rightClick = false;
+      return;
+    }
+    const { tx, tz } = this.state.hoveredTile;
+    if (this.leftClick) {
+      this.world.placeBelt(tx, tz, this.state.buildDir);
+    }
+    if (this.rightClick) {
+      this.world.removeEntity(tx, tz);
+    }
+    this.leftClick = false;
+    this.rightClick = false;
+  }
+
+  private injectItem(): void {
+    if (!this.state.hoveredTile) {
+      return;
+    }
+    this.world.injectItem(this.state.hoveredTile.tx, this.state.hoveredTile.tz, "ore");
+  }
+
+  private save(): void {
+    const json = this.world.serializeChunks(Array.from(this.world.chunks.values()));
+    window.localStorage.setItem("factory-save", json);
+  }
+
+  private load(): void {
+    const json = window.localStorage.getItem("factory-save");
+    if (!json) {
+      return;
+    }
+    this.world.loadFromJSON(json);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+/** Rogue Engine entry point registering the GameManager component. */
+import * as RE from "rogue-engine";
+import GameManager from "./game/GameManager";
+
+RE.registerComponent(GameManager);

--- a/src/render/InstancedBatches.ts
+++ b/src/render/InstancedBatches.ts
@@ -1,0 +1,153 @@
+/** Instanced rendering batches per chunk for ground, belts, and items. */
+import * as THREE from "three";
+import { Chunk } from "../world/Chunk";
+import { CHUNK_SIZE, Dir, SLOTS_PER_BELT, dirToYaw, slotOffset } from "../util/MathUtil";
+import { ITEM_NONE } from "../world/Entities";
+
+const TILE_COUNT = CHUNK_SIZE * CHUNK_SIZE;
+
+type ChunkRenderData = {
+  ground: THREE.InstancedMesh;
+  belts: THREE.InstancedMesh;
+  items: THREE.InstancedMesh;
+};
+
+export class InstancedBatches {
+  private scene: THREE.Scene;
+  private root = new THREE.Group();
+  private chunkMeshes = new Map<string, ChunkRenderData>();
+  private tempObject = new THREE.Object3D();
+
+  private groundGeometry = new THREE.BoxGeometry(1, 0.05, 1);
+  private groundMaterial = new THREE.MeshStandardMaterial({ color: 0x2b2b2b });
+  private beltGeometry = new THREE.BoxGeometry(1, 0.2, 1);
+  private beltMaterial = new THREE.MeshStandardMaterial({ color: 0x5555aa });
+  private itemGeometry = new THREE.BoxGeometry(0.2, 0.2, 0.2);
+  private itemMaterial = new THREE.MeshStandardMaterial({ color: 0xffaa33 });
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+    this.scene.add(this.root);
+  }
+
+  ensureChunk(chunk: Chunk): ChunkRenderData {
+    const key = `${chunk.cx},${chunk.cz}`;
+    let data = this.chunkMeshes.get(key);
+    if (data) {
+      return data;
+    }
+
+    const ground = new THREE.InstancedMesh(this.groundGeometry, this.groundMaterial, TILE_COUNT);
+    ground.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+
+    const belts = new THREE.InstancedMesh(this.beltGeometry, this.beltMaterial, TILE_COUNT);
+    belts.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+
+    const items = new THREE.InstancedMesh(this.itemGeometry, this.itemMaterial, TILE_COUNT * SLOTS_PER_BELT);
+    items.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+
+    this.root.add(ground, belts, items);
+
+    this.populateGround(chunk, ground);
+
+    data = { ground, belts, items };
+    this.chunkMeshes.set(key, data);
+    return data;
+  }
+
+  populateGround(chunk: Chunk, ground: THREE.InstancedMesh): void {
+    let instanceId = 0;
+    for (let lz = 0; lz < CHUNK_SIZE; lz += 1) {
+      for (let lx = 0; lx < CHUNK_SIZE; lx += 1) {
+        const worldX = chunk.cx * CHUNK_SIZE + lx + 0.5;
+        const worldZ = chunk.cz * CHUNK_SIZE + lz + 0.5;
+        this.tempObject.position.set(worldX, -0.03, worldZ);
+        this.tempObject.rotation.set(0, 0, 0);
+        this.tempObject.updateMatrix();
+        ground.setMatrixAt(instanceId, this.tempObject.matrix);
+        instanceId += 1;
+      }
+    }
+    ground.instanceMatrix.needsUpdate = true;
+  }
+
+  syncChunk(chunk: Chunk): void {
+    const data = this.ensureChunk(chunk);
+    if (chunk.dirtyStatic) {
+      this.updateBelts(chunk, data.belts);
+      chunk.dirtyStatic = false;
+    }
+    if (chunk.dirtyItems) {
+      this.updateItems(chunk, data.items);
+      chunk.dirtyItems = false;
+    }
+  }
+
+  updateBelts(chunk: Chunk, mesh: THREE.InstancedMesh): void {
+    let count = 0;
+    for (let index = 0; index < chunk.beltDir.length; index += 1) {
+      const dir = chunk.beltDir[index];
+      if (dir < 0) {
+        continue;
+      }
+      const lx = index % CHUNK_SIZE;
+      const lz = Math.floor(index / CHUNK_SIZE);
+      const worldX = chunk.cx * CHUNK_SIZE + lx + 0.5;
+      const worldZ = chunk.cz * CHUNK_SIZE + lz + 0.5;
+      this.tempObject.position.set(worldX, 0.1, worldZ);
+      this.tempObject.rotation.set(0, dirToYaw(dir as Dir), 0);
+      this.tempObject.updateMatrix();
+      mesh.setMatrixAt(count, this.tempObject.matrix);
+      count += 1;
+    }
+    mesh.count = count;
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  updateItems(chunk: Chunk, mesh: THREE.InstancedMesh): void {
+    let count = 0;
+    for (let index = 0; index < chunk.beltDir.length; index += 1) {
+      const dir = chunk.beltDir[index];
+      if (dir < 0) {
+        continue;
+      }
+      const lx = index % CHUNK_SIZE;
+      const lz = Math.floor(index / CHUNK_SIZE);
+      const baseX = chunk.cx * CHUNK_SIZE + lx + 0.5;
+      const baseZ = chunk.cz * CHUNK_SIZE + lz + 0.5;
+      const baseSlot = index * SLOTS_PER_BELT;
+      for (let slot = 0; slot < SLOTS_PER_BELT; slot += 1) {
+        const itemId = chunk.beltSlots[baseSlot + slot];
+        if (itemId === ITEM_NONE) {
+          continue;
+        }
+        const offset = slotOffset(slot);
+        let offsetX = 0;
+        let offsetZ = 0;
+        switch (dir as Dir) {
+          case Dir.North:
+            offsetZ = -offset;
+            break;
+          case Dir.South:
+            offsetZ = offset;
+            break;
+          case Dir.East:
+            offsetX = offset;
+            break;
+          case Dir.West:
+            offsetX = -offset;
+            break;
+          default:
+            break;
+        }
+        this.tempObject.position.set(baseX + offsetX, 0.25, baseZ + offsetZ);
+        this.tempObject.rotation.set(0, 0, 0);
+        this.tempObject.updateMatrix();
+        mesh.setMatrixAt(count, this.tempObject.matrix);
+        count += 1;
+      }
+    }
+    mesh.count = count;
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+}

--- a/src/sim/Simulator.ts
+++ b/src/sim/Simulator.ts
@@ -1,0 +1,82 @@
+/** Simulation stepper for belt item movement. */
+import { Chunk } from "../world/Chunk";
+import { ITEM_NONE } from "../world/Entities";
+import { CHUNK_SIZE, Dir, DIR_OFFSETS, SLOTS_PER_BELT, chunkKey } from "../util/MathUtil";
+import { World } from "../world/World";
+
+type Transfer = {
+  fromChunk: Chunk;
+  fromIndex: number;
+  toChunk: Chunk;
+  toIndex: number;
+};
+
+export class Simulator {
+  private transfers: Transfer[] = [];
+
+  tick(world: World, activeChunks: Chunk[]): void {
+    this.transfers.length = 0;
+    const activeKeys = new Set(activeChunks.map((chunk) => chunkKey(chunk.cx, chunk.cz)));
+
+    for (const chunk of activeChunks) {
+      const beltDir = chunk.beltDir;
+      for (let index = 0; index < beltDir.length; index += 1) {
+        const dir = beltDir[index];
+        if (dir < 0) {
+          continue;
+        }
+        const base = index * SLOTS_PER_BELT;
+        for (let slot = SLOTS_PER_BELT - 1; slot >= 1; slot -= 1) {
+          const currentIndex = base + slot;
+          const prevIndex = base + slot - 1;
+          if (chunk.beltSlots[currentIndex] === ITEM_NONE && chunk.beltSlots[prevIndex] !== ITEM_NONE) {
+            chunk.beltSlots[currentIndex] = chunk.beltSlots[prevIndex];
+            chunk.beltSlots[prevIndex] = ITEM_NONE;
+            chunk.dirtyItems = true;
+          }
+        }
+
+        const frontIndex = base + (SLOTS_PER_BELT - 1);
+        const itemId = chunk.beltSlots[frontIndex];
+        if (itemId === ITEM_NONE) {
+          continue;
+        }
+
+        const lx = index % CHUNK_SIZE;
+        const lz = Math.floor(index / CHUNK_SIZE);
+        const offset = DIR_OFFSETS[dir as Dir];
+        const tx = chunk.cx * CHUNK_SIZE + lx + offset.dx;
+        const tz = chunk.cz * CHUNK_SIZE + lz + offset.dz;
+        const target = world.getChunkForTile(tx, tz, false);
+        if (!target) {
+          continue;
+        }
+        const targetKey = chunkKey(target.chunk.cx, target.chunk.cz);
+        if (!activeKeys.has(targetKey)) {
+          continue;
+        }
+        const targetIndex = target.chunk.tileIndex(target.lx, target.lz);
+        if (target.chunk.beltDir[targetIndex] < 0) {
+          continue;
+        }
+        const targetSlotIndex = target.chunk.slotIndex(targetIndex, 0);
+        if (target.chunk.beltSlots[targetSlotIndex] !== ITEM_NONE) {
+          continue;
+        }
+        this.transfers.push({
+          fromChunk: chunk,
+          fromIndex: frontIndex,
+          toChunk: target.chunk,
+          toIndex: targetSlotIndex,
+        });
+      }
+    }
+
+    for (const transfer of this.transfers) {
+      transfer.toChunk.beltSlots[transfer.toIndex] = transfer.fromChunk.beltSlots[transfer.fromIndex];
+      transfer.fromChunk.beltSlots[transfer.fromIndex] = ITEM_NONE;
+      transfer.fromChunk.dirtyItems = true;
+      transfer.toChunk.dirtyItems = true;
+    }
+  }
+}

--- a/src/util/MathUtil.ts
+++ b/src/util/MathUtil.ts
@@ -1,0 +1,56 @@
+/** Utility math helpers for grid directions, chunk keys, and slot offsets. */
+import * as THREE from "three";
+
+export const CHUNK_SIZE = 32;
+export const TILE_SIZE = 1;
+export const SLOTS_PER_BELT = 8;
+
+export enum Dir {
+  North = 0,
+  East = 1,
+  South = 2,
+  West = 3,
+}
+
+export const DIR_OFFSETS: Record<Dir, { dx: number; dz: number }> = {
+  [Dir.North]: { dx: 0, dz: -1 },
+  [Dir.East]: { dx: 1, dz: 0 },
+  [Dir.South]: { dx: 0, dz: 1 },
+  [Dir.West]: { dx: -1, dz: 0 },
+};
+
+export function rotateDir(dir: Dir, delta: number): Dir {
+  const value = (dir + delta + 4) % 4;
+  return value as Dir;
+}
+
+export function dirToYaw(dir: Dir): number {
+  switch (dir) {
+    case Dir.North:
+      return Math.PI;
+    case Dir.East:
+      return -Math.PI / 2;
+    case Dir.South:
+      return 0;
+    case Dir.West:
+      return Math.PI / 2;
+    default:
+      return 0;
+  }
+}
+
+export function chunkKey(cx: number, cz: number): string {
+  return `${cx},${cz}`;
+}
+
+export function slotOffset(slotIndex: number): number {
+  return (slotIndex + 0.5) / SLOTS_PER_BELT - 0.5;
+}
+
+export function tempVec3(x: number, y: number, z: number, out?: THREE.Vector3): THREE.Vector3 {
+  if (out) {
+    out.set(x, y, z);
+    return out;
+  }
+  return new THREE.Vector3(x, y, z);
+}

--- a/src/world/Chunk.ts
+++ b/src/world/Chunk.ts
@@ -1,0 +1,34 @@
+/** Chunk data container for belts and item slots. */
+import { CHUNK_SIZE, SLOTS_PER_BELT } from "../util/MathUtil";
+import { ITEM_NONE } from "./Entities";
+
+export class Chunk {
+  readonly cx: number;
+  readonly cz: number;
+  readonly beltDir: Int8Array;
+  readonly beltSlots: Uint16Array;
+  dirtyStatic = true;
+  dirtyItems = true;
+
+  constructor(cx: number, cz: number) {
+    this.cx = cx;
+    this.cz = cz;
+    const tiles = CHUNK_SIZE * CHUNK_SIZE;
+    this.beltDir = new Int8Array(tiles);
+    this.beltDir.fill(-1);
+    this.beltSlots = new Uint16Array(tiles * SLOTS_PER_BELT);
+  }
+
+  tileIndex(lx: number, lz: number): number {
+    return lz * CHUNK_SIZE + lx;
+  }
+
+  slotIndex(tileIndex: number, slot: number): number {
+    return tileIndex * SLOTS_PER_BELT + slot;
+  }
+
+  clearSlots(tileIndex: number): void {
+    const start = tileIndex * SLOTS_PER_BELT;
+    this.beltSlots.fill(ITEM_NONE, start, start + SLOTS_PER_BELT);
+  }
+}

--- a/src/world/Entities.ts
+++ b/src/world/Entities.ts
@@ -1,0 +1,35 @@
+/** Entity definitions and item registry for belt slots. */
+
+export const ITEM_NONE = 0;
+
+export class ItemRegistry {
+  private nextId = 1;
+  private nameToId = new Map<string, number>();
+  private idToName = new Map<number, string>();
+
+  register(name: string): number {
+    const existing = this.nameToId.get(name);
+    if (existing) {
+      return existing;
+    }
+    const id = this.nextId++;
+    this.nameToId.set(name, id);
+    this.idToName.set(id, name);
+    return id;
+  }
+
+  getId(name: string): number {
+    const id = this.nameToId.get(name);
+    if (!id) {
+      return this.register(name);
+    }
+    return id;
+  }
+
+  getName(id: number): string {
+    return this.idToName.get(id) ?? "unknown";
+  }
+}
+
+export const itemRegistry = new ItemRegistry();
+itemRegistry.register("ore");

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -1,0 +1,138 @@
+/** World chunk map and coordinate helper utilities. */
+import * as THREE from "three";
+import { CHUNK_SIZE, TILE_SIZE, chunkKey } from "../util/MathUtil";
+import { Chunk } from "./Chunk";
+import { itemRegistry, ITEM_NONE } from "./Entities";
+
+export type TileCoord = { tx: number; tz: number };
+export type ChunkCoord = { cx: number; cz: number; lx: number; lz: number };
+
+export class World {
+  readonly chunks = new Map<string, Chunk>();
+
+  worldToTile(pos: THREE.Vector3): TileCoord {
+    return { tx: Math.floor(pos.x / TILE_SIZE), tz: Math.floor(pos.z / TILE_SIZE) };
+  }
+
+  tileToWorld(tx: number, tz: number, out?: THREE.Vector3): THREE.Vector3 {
+    const x = (tx + 0.5) * TILE_SIZE;
+    const z = (tz + 0.5) * TILE_SIZE;
+    if (out) {
+      out.set(x, 0, z);
+      return out;
+    }
+    return new THREE.Vector3(x, 0, z);
+  }
+
+  tileToChunk(tx: number, tz: number): ChunkCoord {
+    const cx = Math.floor(tx / CHUNK_SIZE);
+    const cz = Math.floor(tz / CHUNK_SIZE);
+    const lx = tx - cx * CHUNK_SIZE;
+    const lz = tz - cz * CHUNK_SIZE;
+    return { cx, cz, lx, lz };
+  }
+
+  getChunk(cx: number, cz: number, create = true): Chunk | undefined {
+    const key = chunkKey(cx, cz);
+    let chunk = this.chunks.get(key);
+    if (!chunk && create) {
+      chunk = new Chunk(cx, cz);
+      this.chunks.set(key, chunk);
+    }
+    return chunk;
+  }
+
+  getChunkForTile(tx: number, tz: number, create = true): { chunk: Chunk; lx: number; lz: number } | undefined {
+    const { cx, cz, lx, lz } = this.tileToChunk(tx, tz);
+    const chunk = this.getChunk(cx, cz, create);
+    if (!chunk) {
+      return undefined;
+    }
+    return { chunk, lx, lz };
+  }
+
+  placeBelt(tx: number, tz: number, dir: number): void {
+    const data = this.getChunkForTile(tx, tz, true);
+    if (!data) {
+      return;
+    }
+    const { chunk, lx, lz } = data;
+    const index = chunk.tileIndex(lx, lz);
+    chunk.beltDir[index] = dir;
+    chunk.clearSlots(index);
+    chunk.dirtyStatic = true;
+    chunk.dirtyItems = true;
+  }
+
+  removeEntity(tx: number, tz: number): void {
+    const data = this.getChunkForTile(tx, tz, false);
+    if (!data) {
+      return;
+    }
+    const { chunk, lx, lz } = data;
+    const index = chunk.tileIndex(lx, lz);
+    chunk.beltDir[index] = -1;
+    chunk.clearSlots(index);
+    chunk.dirtyStatic = true;
+    chunk.dirtyItems = true;
+  }
+
+  getActiveChunks(center: THREE.Vector3, radius: number): Chunk[] {
+    const { tx, tz } = this.worldToTile(center);
+    const { cx, cz } = this.tileToChunk(tx, tz);
+    const results: Chunk[] = [];
+    for (let dz = -radius; dz <= radius; dz += 1) {
+      for (let dx = -radius; dx <= radius; dx += 1) {
+        const chunk = this.getChunk(cx + dx, cz + dz, true);
+        if (chunk) {
+          results.push(chunk);
+        }
+      }
+    }
+    return results;
+  }
+
+  injectItem(tx: number, tz: number, itemName: string): void {
+    const data = this.getChunkForTile(tx, tz, false);
+    if (!data) {
+      return;
+    }
+    const { chunk, lx, lz } = data;
+    const index = chunk.tileIndex(lx, lz);
+    if (chunk.beltDir[index] < 0) {
+      return;
+    }
+    const slotIndex = chunk.slotIndex(index, 0);
+    if (chunk.beltSlots[slotIndex] !== ITEM_NONE) {
+      return;
+    }
+    chunk.beltSlots[slotIndex] = itemRegistry.getId(itemName);
+    chunk.dirtyItems = true;
+  }
+
+  serializeChunks(chunks: Chunk[]): string {
+    const payload = chunks.map((chunk) => ({
+      cx: chunk.cx,
+      cz: chunk.cz,
+      beltDir: Array.from(chunk.beltDir),
+      beltSlots: Array.from(chunk.beltSlots),
+    }));
+    return JSON.stringify({ version: 1, chunks: payload });
+  }
+
+  loadFromJSON(json: string): void {
+    const data = JSON.parse(json) as {
+      version: number;
+      chunks: Array<{ cx: number; cz: number; beltDir: number[]; beltSlots: number[] }>;
+    };
+    this.chunks.clear();
+    for (const entry of data.chunks) {
+      const chunk = new Chunk(entry.cx, entry.cz);
+      chunk.beltDir.set(entry.beltDir.map((value) => value));
+      chunk.beltSlots.set(entry.beltSlots.map((value) => value));
+      chunk.dirtyStatic = true;
+      chunk.dirtyItems = true;
+      this.chunks.set(chunkKey(entry.cx, entry.cz), chunk);
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a code-only Rogue Engine prototype that implements a 3D top-down factory vertical slice with deterministic chunked world addressing and a simple belt-based item flow. 
- Prioritize a performance-minded architecture using instanced rendering and fixed-step simulation, plus minimal save/load and in-editor controls for building and testing.

### Description

- Added a chunked world and helpers in `src/world/World.ts` and `src/util/MathUtil.ts` with `CHUNK_SIZE = 32`, tile/chunk coordinate conversions (`worldToTile`, `tileToWorld`, `tileToChunk`) and `chunkKey` utilities. 
- Implemented `Chunk` data in `src/world/Chunk.ts` storing `beltDir: Int8Array` and compact `beltSlots: Uint16Array` with `dirtyStatic` and `dirtyItems` flags and helper indexing methods. 
- Introduced a compact `ItemRegistry` in `src/world/Entities.ts` to map item names to small integers and registered a sample `"ore"` item. 
- Implemented the belt simulation in `src/sim/Simulator.ts` that runs on a fixed tick and performs intra-tile slot shifts and cross-tile transfers, batching transfers to maintain deterministic behavior. 
- Built GPU-friendly instanced rendering in `src/render/InstancedBatches.ts` with one `THREE.InstancedMesh` per chunk for ground, belts, and items and update logic that only rebuilds instance matrices when a chunk's `dirtyStatic` or `dirtyItems` flags are set. 
- Added `InputController` in `src/input/InputController.ts` implementing top-down camera controls (WASD, wheel zoom, middle-drag), raycast-to-tile, ghost preview, left/right click to place/remove belts, `Q/E` rotation, `1` to inject an item, and `F5/F9` save/load to `localStorage`. 
- Added `GameManager` (`src/game/GameManager.ts`) as a Rogue Engine component that wires everything together, uses a tick accumulator at 20 Hz (`dt = 0.05`), restricts simulation to active chunks around the camera, and synchronizes rendering per-chunk. 
- Registered component in `src/main.ts` and appended a short README section documenting controls and how to run the prototype in Rogue Engine. 

### Testing

- No automated tests were executed as part of this change; the patch adds the prototype implementation and README but does not include CI/unit tests. 
- Basic manual validation steps are provided in the README and the code includes save/load hooks (`F5/F9`) and an item injection hotkey (`1`) to exercise belt flow during runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698609e1b9f8832a971e24d68aa6f264)